### PR TITLE
Remove mutable references for accept and incoming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ impl MemoryListener {
     ///     }
     /// }
     /// ```
-    pub fn incoming(&mut self) -> Incoming<'_> {
+    pub fn incoming(&self) -> Incoming<'_> {
         Incoming { inner: self }
     }
 
@@ -216,7 +216,7 @@ impl MemoryListener {
     ///     Err(e) => println!("couldn't get client: {:?}", e),
     /// }
     /// ```
-    pub fn accept(&mut self) -> Result<MemorySocket> {
+    pub fn accept(&self) -> Result<MemorySocket> {
         self.incoming.iter().next().ok_or_else(|| unreachable!())
     }
 }
@@ -230,7 +230,7 @@ impl MemoryListener {
 /// [`incoming`]: struct.MemoryListener.html#method.incoming
 /// [`MemoryListener`]: struct.MemoryListener.html
 pub struct Incoming<'a> {
-    inner: &'a mut MemoryListener,
+    inner: &'a MemoryListener,
 }
 
 impl<'a> Iterator for Incoming<'a> {

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -15,7 +15,7 @@ fn listener_bind() -> Result<()> {
 
 #[test]
 fn simple_connect() -> Result<()> {
-    let mut listener = MemoryListener::bind(10)?;
+    let listener = MemoryListener::bind(10)?;
 
     let mut dialer = MemorySocket::connect(10)?;
     let mut listener_socket = listener.incoming().next().unwrap()?;
@@ -32,7 +32,7 @@ fn simple_connect() -> Result<()> {
 
 #[test]
 fn listen_on_port_zero() -> Result<()> {
-    let mut listener = MemoryListener::bind(0)?;
+    let listener = MemoryListener::bind(0)?;
     let listener_addr = listener.local_addr();
 
     let mut dialer = MemorySocket::connect(listener_addr)?;
@@ -58,7 +58,7 @@ fn listen_on_port_zero() -> Result<()> {
 #[test]
 fn listener_correctly_frees_port_on_drop() -> Result<()> {
     fn connect_on_port(port: u16) -> Result<()> {
-        let mut listener = MemoryListener::bind(port)?;
+        let listener = MemoryListener::bind(port)?;
         let mut dialer = MemorySocket::connect(port)?;
         let mut listener_socket = listener.incoming().next().unwrap()?;
 


### PR DESCRIPTION
The structs being emulated (TcpStream et al) are not &mut for the listening and accept methods,
so it seems reasonable that memory-socket shouldn't be either. Since Flume channels don't require mutable references, it was easy to take them out. Tests pass; is there any reason not to do this? 